### PR TITLE
fix: height가 812px보다 작을 때 가운데 부분만 보이는 이슈 해결

### DIFF
--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -3,11 +3,10 @@ import styled from "styled-components";
 export const AppContainer = styled.div`
   max-width: 375px;
   width: 100%;
-  height: 812px;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  min-height: 100vh;
+  height: 100%;
+  position: relative;
+  margin: 0 auto;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;


### PR DESCRIPTION
# 🎯 이슈 번호

- #

## 🏁 작업 내용

- height가 812px보다 작을 때 가운데 부분만 보이는 이슈 해결
-

## 💬 리뷰 요구 사항

-
-

## 📢 참고 사항

-
-

## 🖼️ 작업물 스크린샷 or 영상
