### PR TITLE
feat: 카드 뒤집을 때 뒤의 카드가 보이지 않도록 수정

### DIFF
--- a/src/components/TopicCards/index.tsx
+++ b/src/components/TopicCards/index.tsx
@@ -65,12 +65,17 @@ const TopicCards = ({ topics, onHasViewedAllCards }: TopicCardsProps) => {
           {slides.map((_, index) => (
             <SwiperSlide key={`slide-${index}`}>
               {topicsToShow.map((stackTopic, stackIndex) => (
-                <Card
+                <S.CardWrapper
                   key={`${stackTopic}-${stackIndex}`}
-                  content={stackTopic.content}
-                  situationName={stackTopic.situationName}
-                  id={stackTopic.id}
-                />
+                  isVisible={index === currentIndex}
+                >
+                  <Card
+                    key={`${stackTopic}-${stackIndex}`}
+                    content={stackTopic.content}
+                    situationName={stackTopic.situationName}
+                    id={stackTopic.id}
+                  />
+                </S.CardWrapper>
               ))}
             </SwiperSlide>
           ))}

--- a/src/components/TopicCards/styled.ts
+++ b/src/components/TopicCards/styled.ts
@@ -33,3 +33,9 @@ export const ProgressText = styled.span`
   ${FONT.body16}
   opacity: 0.5;
 `;
+
+export const CardWrapper = styled.div<{
+  isVisible: boolean;
+}>`
+  visibility: ${({ isVisible }) => (isVisible ? "visible" : "hidden")};
+`;


### PR DESCRIPTION
# 🎯 이슈 번호

- #

## 🏁 작업 내용

- 카드 뒤집을 때 뒤의 카드가 보이지 않도록 수정
-

## 💬 리뷰 요구 사항

-
-

## 📢 참고 사항

-
-

## 🖼️ 작업물 스크린샷 or 영상
