### PR TITLE
feat: 공유하기 element dataset 추가

### DIFF
--- a/src/components/SituationFinish/index.tsx
+++ b/src/components/SituationFinish/index.tsx
@@ -94,8 +94,16 @@ const Finish: React.FC<FinishProps> = ({ topics }) => {
           친구에게도 <S.FooterStrong>“말해머해”</S.FooterStrong>를 알려주세요
         </S.FooterP>
         <S.ShareContainer>
-          <S.ShareImage src={KaKao} onClick={handleKakaoShare} />
-          <S.ShareImage src={Share} onClick={handleShare} />
+          <S.ShareImage
+            data-gtm="kakao-share"
+            src={KaKao}
+            onClick={handleKakaoShare}
+          />
+          <S.ShareImage
+            data-gtm="url-share"
+            src={Share}
+            onClick={handleShare}
+          />
         </S.ShareContainer>
       </S.Footer>
       <SummaryModal isOpen={isOpen} closeModal={closeModal} topics={topics} />


### PR DESCRIPTION
## 🏁 작업 내용

- 카카오, url 공유하기 element dataset 추가
- 유저가 해당 버튼을 얼마나 클릭했는지 확인하기 위함(GTM 부착, 이벤트 확인 가능)


