### PR TITLE
메인, 토픽리스트, 토픽카드 수정

### DIFF
--- a/src/components/Card/CardBack/index.tsx
+++ b/src/components/Card/CardBack/index.tsx
@@ -33,12 +33,17 @@ function CardBack({ situationName, id, content, $situationColor }: CardProps) {
       <S.Card $situationColor={$situationColor}>
         <CardDotEffect $color={$situationColor} />
         <S.Box>
-          <S.SubTitle $situationColor={$situationColor}>
-            No.
-            <S.CardIndex $situationColor={$situationColor}>
-              {id}&ensp;#{situationName} 토픽
-            </S.CardIndex>
-          </S.SubTitle>
+          <S.TopicIndexInfoBox>
+            <S.CardIndexBox $situationColor={$situationColor}>
+              <S.SubTitle $situationColor={$situationColor}>No.</S.SubTitle>
+              <S.CardIndex $situationColor={$situationColor}>{id}</S.CardIndex>
+            </S.CardIndexBox>
+            <S.TopicBox>
+              <S.TopicTitle $situationColor={$situationColor}>
+                #{situationName} 토픽
+              </S.TopicTitle>
+            </S.TopicBox>
+          </S.TopicIndexInfoBox>
           <S.Title>{content}</S.Title>
           <S.TipBox>
             <S.TipText>

--- a/src/components/Card/CardBack/styled.ts
+++ b/src/components/Card/CardBack/styled.ts
@@ -32,30 +32,57 @@ export const Box = styled.div`
   transform: translateX(-50%);
 `;
 
+export const TopicIndexInfoBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  position: absolute;
+  top: 2rem;
+  left: 30%;
+  transform: translateX(-30%);
+  width: 70%;
+`;
+
+export const CardIndexBox = styled.div<CardStyleProps>`
+  display: flex;
+  flex-direction: row;
+  gap: 0.3rem;
+`;
+
 export const SubTitle = styled.p<CardStyleProps>`
+  display: flex;
+  align-items: flex-end;
   color: ${(props) => ensureHexColor(props.$situationColor?.mainCardColor)};
   font-family: "esamanru OTF";
   font-size: 0.75rem;
   line-height: 150%; /* 1.3125rem */
-  display: flex;
-  align-items: flex-end;
-  gap: 0.2rem;
-  position: absolute;
-  top: 2rem;
-  left: 30%;
-  transform: translateX(-50%);
 `;
 
 export const CardIndex = styled.span<CardStyleProps>`
+  display: flex;
+  align-items: center;
   color: ${(props) => ensureHexColor(props.$situationColor?.mainCardColor)};
   font-family: Pretendard;
   font-size: 1.125rem;
   font-weight: 600;
   line-height: 150%;
   letter-spacing: -0.0225rem;
+`;
+
+export const TopicBox = styled.div`
+  flex-grow: 1;
+  text-align: right;
+  margin-left: 0.5rem;
+`;
+
+export const TopicTitle = styled.span<CardStyleProps>`
   display: flex;
-  flex-direction: row;
-  gap: 0.5rem;
+  align-items: center;
+  color: ${(props) => ensureHexColor(props.$situationColor?.mainCardColor)};
+  font-family: Pretendard;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 150%;
+  letter-spacing: -0.0225rem;
 `;
 
 export const Title = styled.p`

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -39,9 +39,9 @@ export const InstructionPanelContent = styled(PanelContent)`
 
 export const MainContent = styled.main`
   background: ${(props) => props.theme.colors["--card-color-blue-100"]};
-  height: 100vh;
+  height: 100dvh;
   flex: 0 0 375px;
-  min-height: 100vh;
+  min-height: 100dvh;
   margin: 0 auto;
 `;
 

--- a/src/components/Main/styled.ts
+++ b/src/components/Main/styled.ts
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const Container = styled.main`
   width: 100%;
-  height: 100vh;
+  min-height: 100dvh;
 `;
 
 export const TitleBox = styled.div`
@@ -68,7 +68,7 @@ export const ContentBox = styled.div`
   padding: 0 1rem;
 
   @media screen and (min-width: 1024px) {
-    height: calc(100vh - 282px);
+    height: calc(100dvh - 282px);
   }
 `;
 

--- a/src/components/Modal/styled.ts
+++ b/src/components/Modal/styled.ts
@@ -24,7 +24,7 @@ export const Container = styled.div<{ $isOpen: boolean }>`
   left: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   background-color: rgba(0, 0, 0, 0.3);
   animation: ${({ $isOpen }) => ($isOpen ? openEffect : closeEffect)} 0.25s ease;
   z-index: 999;

--- a/src/components/TopicsBySituation/styled.ts
+++ b/src/components/TopicsBySituation/styled.ts
@@ -6,7 +6,9 @@ import { ensureHexColor } from "../Card";
 export const Main = styled.main<CardStyleProps>`
   background: ${(props) =>
     ensureHexColor(props.$situationColor?.backgroundColor)};
-  min-height: 100vh;
+  height: calc(100dvh - 53px);
+  overflow: hidden;
+  touch-action: none;
 `;
 
 export const SituationBox = styled.div`

--- a/src/hooks/useRandomTopics.ts
+++ b/src/hooks/useRandomTopics.ts
@@ -22,6 +22,7 @@ export const useRandomTopics = () => {
       return pagination.page + 1;
     },
     initialPageParam: 1,
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/src/hooks/useTopicsBySituation.ts
+++ b/src/hooks/useTopicsBySituation.ts
@@ -13,5 +13,6 @@ export const useTopicsBySituation = (situationId: string) => {
     queryKey: ["topicsBySituation", situationId],
     queryFn: () =>
       instance.get(`/topic/situation/${situationId}`).then((res) => res.data),
+    refetchOnWindowFocus: false,
   });
 };


### PR DESCRIPTION
# 🎯 이슈 번호

- #97 
- #98
- #99 
- #100
- #101


## 🏁 작업 내용

- fix. 웹에서 다른 페이지 및 뒤로가기 후 다시 접근 하면 이전 선택지가 등장했다가 토픽 넘어가는 현상 수정(랜덤토픽 페이지, 토픽페이지)
- fix. 카드 뒷면 긴 토픽 경우 no이 영역을 이탈하는 현상 수정
- fix. 토픽 리스트에서 끝까지 내리고 나면 맨 위로 간헐적으로 안 올라가는 현상 수정
- fix. 메인 화면 영역 수정 vh -> dvh
- fix. 아이폰 카드 스와이프 잘 안되는 현상 수정

## 💬 리뷰 요구 사항

-

## 📢 참고 사항

-
